### PR TITLE
Fix a bug in the password-reset functionality

### DIFF
--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -338,7 +338,10 @@ def send_email(subject, sender, recipients, body):
     msg = Message(subject, sender=sender, recipients=recipients)
     msg.body = body
 
-    t = threading.Thread(target=send_async_email, args=(current_app, msg))
+    t = threading.Thread(
+        target=send_async_email,
+        args=(current_app._get_current_object(), msg),
+    )
     t.start()
 
 


### PR DESCRIPTION
high-level view of the bug
---

1. create a new user (with a real email address!) (by issuing a valid `POST` request to the `/api/users` endpoint)
2. request a password-reset for the created user (by issuing a valid `POST` request to the `/api/request-password-reset` endpoint)
3. observe that the previous step causes the process responsible for serving the backend application to report the following error:
```
# ...
  File "<absolute-path-to>/vocab-treasury/backend/src/api/users.py", line 346, in send_async_email
    with app.app_context():
# ...
  File "<absolute-path-to>/vocab-treasury/backend/venv/lib/python3.8/site-packages/werkzeug/local.py", line 306, in _get_current_object
    return self.__local()
  File "<absolute-path-to>/vocab-treasury/backend/venv/lib/python3.8/site-packages/flask/globals.py", line 52, in _find_app
    raise RuntimeError(_app_ctx_err_msg)
RuntimeError: Working outside of application context.

This typically means that you attempted to use functionality that needed
to interface with the current application object in some way. To solve
this, set up an application context with app.app_context().  See the
documentation for more information.
```

detailed view of the bug
---

1. place a breakpoint at https://github.com/kaloyan-marinov/vocab-treasury/blob/a454f9c32e6aa0a229127a209a8f0914cbd64fb1/backend/src/api/users.py#L341
2. place a breakpoint at https://github.com/kaloyan-marinov/vocab-treasury/blob/a454f9c32e6aa0a229127a209a8f0914cbd64fb1/backend/src/api/users.py#L346
3. repeat the steps from the previous section
4. observe that, when the debugger reaches the second breakpoint, the following hold true:
```
>>> type(app)
<class 'werkzeug.local.LocalProxy'>
>>> app
<LocalProxy unbound>
```