### PR TITLE
Get the currently skipped test case for deleting a `User` resource to PASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,8 +546,6 @@ and use `localhost` to serve a frontend application.
             -u ${EMAIL_2_2}:456 \
             localhost:5000/api/users/2 \
             | json_pp
-        
-
         ```
 
 4. set up the frontend:

--- a/README.md
+++ b/README.md
@@ -154,13 +154,14 @@ and use `localhost` to serve a frontend application.
         # Verify that repeating the previous step now returns the following:
 
         mysql> SHOW TABLES;
-        +--------------------+
-        | Tables_in_db-4-v-t |
-        +--------------------+
-        | alembic_version    |
-        | example            |
-        | user               |
-        +--------------------+
+        +----------------------+
+        | Tables_in_db-4-v-t   |
+        +----------------------+
+        | alembic_version      |
+        | email_address_change |
+        | example              |
+        | user                 |
+        +----------------------+
         3 rows in set (0.00 sec)
 
         
@@ -168,20 +169,21 @@ and use `localhost` to serve a frontend application.
         # Also, verify that the following commands generate the indicated outputs:
         
         mysql> SHOW CREATE TABLE user;
-        +-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | Table | Create Table                                                                                                                                                                                                                                                                                                                                                                              |
-        +-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        +-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | Table | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                        |
+        +-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
         | user  | CREATE TABLE `user` (
           `id` int NOT NULL AUTO_INCREMENT,
           `username` varchar(32) COLLATE utf8mb4_bin NOT NULL,
           `email` varchar(128) COLLATE utf8mb4_bin NOT NULL,
           `password_hash` varchar(128) COLLATE utf8mb4_bin NOT NULL,
+          `is_confirmed` tinyint(1) DEFAULT NULL,
           PRIMARY KEY (`id`),
           UNIQUE KEY `email` (`email`),
           UNIQUE KEY `username` (`username`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
-        +-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        1 row in set (0.01 sec)
+        +-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        1 row in set (0.00 sec)
 
         mysql> SHOW CREATE TABLE example;
         +---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -200,8 +202,24 @@ and use `localhost` to serve a frontend application.
           CONSTRAINT `example_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
         +---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        1 row in set (0.00 sec)
-        ```
+        1 row in set (0.01 sec)
+
+        mysql> SHOW CREATE TABLE email_address_change;
+        +----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | Table                | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+        +----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | email_address_change | CREATE TABLE `email_address_change` (
+          `id` int NOT NULL AUTO_INCREMENT,
+          `user_id` int NOT NULL,
+          `old` varchar(128) COLLATE utf8mb4_bin NOT NULL,
+          `new` varchar(128) COLLATE utf8mb4_bin NOT NULL,
+          `created` datetime NOT NULL,
+          PRIMARY KEY (`id`),
+          KEY `user_id` (`user_id`),
+          CONSTRAINT `email_address_change_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+        +----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        1 row in set (0.01 sec)
 
     - create a pre-commit Git hook that runs the `black` formatter for Python code:
         ```
@@ -290,7 +308,7 @@ and use `localhost` to serve a frontend application.
 
         ---
 
-        $ export EMAIL_2=<another-real-email-address-that-you-have-access-to>
+        $ export EMAIL_2_1=<another-real-email-address-that-you-have-access-to>
 
         $ curl -v \
             -X POST \
@@ -298,7 +316,7 @@ and use `localhost` to serve a frontend application.
             -d \
                 "{ \
                     \"username\": \"ms\", \
-                    \"email\": \"${EMAIL_2}\", \
+                    \"email\": \"${EMAIL_2_1}\", \
                     \"password\": \"456\"\
                 }" \
             localhost:5000/api/users \
@@ -306,7 +324,7 @@ and use `localhost` to serve a frontend application.
 
         201
 
-        # Check the inbox of `EMAIL_1`.
+        # Check the inbox of `EMAIL_2_1`.
         # You will receive an email with instructions
         # for confirming the newly-created user's email address.
         # Follow those instructions.
@@ -372,10 +390,24 @@ and use `localhost` to serve a frontend application.
 
         200
 
+
+
         $ curl -v \
             -X PUT \
             -H "Content-Type: application/json" \
-            -u ${EMAIL_2}:456 \
+            -u ${EMAIL_2_1}:wrong-password \
+            -d "{ \
+                    \"username\": \"MS\" \
+                }" \
+            localhost:5000/api/users/2 \
+            | json_pp
+
+        401
+
+        $ curl -v \
+            -X PUT \
+            -H "Content-Type: application/json" \
+            -u ${EMAIL_2_1}:456 \
             -d "{ \
                     \"username\": \"JD\" \
                 }" \
@@ -384,29 +416,36 @@ and use `localhost` to serve a frontend application.
 
         400
 
-        # $ curl -v \
-        #     -X PUT \
-        #     -H "Content-Type: application/json" \
-        #     -u ${EMAIL_2}:456 \
-        #     -d "{ \
-        #             \"email\": \"${EMAIL_1}\" \
-        #         }" \
-        #     localhost:5000/api/users/2 \
-        #     | json_pp
-        # 
-        # 400
+        $ curl -v \
+            -X PUT \
+            -H "Content-Type: application/json" \
+            -u ${EMAIL_2_1}:456 \
+            -d "{ \
+                    \"email\": \"${EMAIL_1}\" \
+                }" \
+            localhost:5000/api/users/2 \
+            | json_pp
+        
+        400
+
+        $ export EMAIL_2_2=MARY.SMITH@PROTONMAIL.COM
 
         $ curl -v \
             -X PUT \
             -H "Content-Type: application/json" \
-            -u ${EMAIL_2}:wrong-password \
+            -u ${EMAIL_2_1}:456 \
             -d "{ \
-                    \"username\": \"MS\" \
+                    \"email\": \"${EMAIL_2_2}\" \
                 }" \
             localhost:5000/api/users/2 \
             | json_pp
+        
+        202
 
-        401
+        # Check the inbox of `EMAIL_2_2`.
+        # You will receive an email with instructions
+        # for confirming the new email address.
+        # Follow those instructions.
 
         ---
 
@@ -442,7 +481,7 @@ and use `localhost` to serve a frontend application.
 
         $ curl -v \
             -X DELETE \
-            -u ${EMAIL_2}:wrong-password \
+            -u ${EMAIL_2_2}:wrong-password \
             localhost:5000/api/users/2 \
             | json_pp
 
@@ -452,8 +491,9 @@ and use `localhost` to serve a frontend application.
 
         $ curl -v \
             -X POST \
-            -u ${EMAIL_2}:456 \
-            localhost:5000/api/tokens
+            -u ${EMAIL_2_2}:456 \
+            localhost:5000/api/tokens \
+            | json_pp
 
         200
 
@@ -500,6 +540,14 @@ and use `localhost` to serve a frontend application.
             | json_pp
         
         200
+
+        $ curl -v \
+            -X DELETE \
+            -u ${EMAIL_2_2}:456 \
+            localhost:5000/api/users/2 \
+            | json_pp
+        
+
         ```
 
 4. set up the frontend:

--- a/backend/scripts/script_2023_03_19_15_30_delete_users_that_have_not_been_confirmed_yet.py
+++ b/backend/scripts/script_2023_03_19_15_30_delete_users_that_have_not_been_confirmed_yet.py
@@ -75,15 +75,6 @@ if __name__ == "__main__":
         users = User.query.filter(
             (User.is_confirmed == None) | (User.is_confirmed == False)
         )
-        # fmt: off
-        '''
-        print(f"{users.count() = }")
-         user_17 = User.query.get(17)
-        print(f"{user_17 = }")
-        print(f"{user_17.is_confirmed = }")
-        print(type(user_17.is_confirmed))
-        '''
-        # fmt: on
 
         for u in users:
             logger.info("processing %s", repr(u))

--- a/backend/scripts/script_2023_03_19_15_30_delete_users_that_have_not_been_confirmed_yet.py
+++ b/backend/scripts/script_2023_03_19_15_30_delete_users_that_have_not_been_confirmed_yet.py
@@ -72,7 +72,18 @@ if __name__ == "__main__":
     )
 
     with app.app_context():
-        users = User.query.filter_by(is_confirmed=False)
+        users = User.query.filter(
+            (User.is_confirmed == None) | (User.is_confirmed == False)
+        )
+        # fmt: off
+        '''
+        print(f"{users.count() = }")
+         user_17 = User.query.get(17)
+        print(f"{user_17 = }")
+        print(f"{user_17.is_confirmed = }")
+        print(type(user_17.is_confirmed))
+        '''
+        # fmt: on
 
         for u in users:
             logger.info("processing %s", repr(u))

--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -384,12 +384,14 @@ def delete_user(user_id):
     try:
         db.session.commit()
     except sqlalchemy.exc.IntegrityError:
+        db.session.rollback()
+
         r = jsonify(
             {
                 "error": "Bad Request",
                 "message": (
                     "Your User resource cannot be deleted at this time,"
-                    " because there exists at least one Example resource"
+                    " because there exists at least one resource"
                     " that is associated with your User resource."
                 ),
             }

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -60,6 +60,19 @@ class User(PaginatedAPIMixin, db.Model):
     password_hash = db.Column(db.String(128), nullable=False)
     is_confirmed = db.Column(db.Boolean)
 
+    examples = db.relationship(
+        "Example",
+        lazy="dynamic",
+        backref="user",
+        # cascade="all, delete, delete-orphan",
+    )
+    email_address_changes = db.relationship(
+        "EmailAddressChange",
+        lazy="dynamic",
+        backref="user",
+        # cascade="all, delete, delete-orphan",
+    )
+
     def to_dict(self):
         """Export `self` to a dict, which omits any and all sensitive information."""
         return {"id": self.id, "username": self.username}

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -64,13 +64,11 @@ class User(PaginatedAPIMixin, db.Model):
         "Example",
         lazy="dynamic",
         backref="user",
-        # cascade="all, delete, delete-orphan",
     )
     email_address_changes = db.relationship(
         "EmailAddressChange",
         lazy="dynamic",
         backref="user",
-        # cascade="all, delete, delete-orphan",
     )
 
     def to_dict(self):

--- a/backend/tests/api/test_4_examples.py
+++ b/backend/tests/api/test_4_examples.py
@@ -1478,7 +1478,7 @@ class Test_06_DeleteUserHavingResources(TestBaseForExampleResources_2):
     """
     Test the request responsible for deleting a specific `User` resource
     in the specific case where
-    there exist `Example` resources
+    there exist resources (in other database models)
     that are associated with the targeted `User` resource.
     """
 

--- a/backend/tests/api/test_4_examples.py
+++ b/backend/tests/api/test_4_examples.py
@@ -1496,27 +1496,7 @@ class Test_06_DeleteUserHavingResources(TestBaseForExampleResources_2):
             user_data_1["password"],
         )
 
-    @unittest.skip(
-        "as long as the 'TODO: (2023/03/20, 07:21)' has not been handled,"
-        " this test case has to be skipped"
-    )
     def test_1_prevent_deletion(self):
-        # TODO: (2023/03/20, 07:21)
-        #       resolve v-t-i-69
-        #       :=
-        #       get this test to pass
-        #       (
-        #       when running the backend application in development mode
-        #       against a MySQL database,
-        #       the backend does prevent the deletion of a `User` resource,
-        #       associated with which there exists at least one `Example` resource
-        #
-        #       however,
-        #       running this test,
-        #       which is backed by an in-memory SQLite database,
-        #       does not prevent the deletion of an analogous `User` resource
-        #       )
-
         # Arrange.
         source_language = "Finnish"
         new_word = "kieli"
@@ -1544,9 +1524,23 @@ class Test_06_DeleteUserHavingResources(TestBaseForExampleResources_2):
 
         # Assert.
         body_str = rv.get_data(as_text=True)
+        body = json.loads(body_str)
 
         self.assertEqual(rv.status_code, 400)
-        self.assertEqual(body_str, "")
+        self.assertEqual(
+            body,
+            {
+                "error": "Bad Request",
+                "message": (
+                    "Your User resource cannot be deleted at this time,"
+                    " because there exists at least one resource"
+                    " that is associated with your User resource."
+                ),
+            },
+        )
 
-        examples = Example.query.filter_by(user_id=self._u_r_1.id).all()
-        self.assertEqual(len(examples), 1)
+        users = User.query.filter_by(id=self._u_r_1.id)
+        self.assertEqual(users.count(), 1)
+
+        examples = Example.query.filter_by(user_id=self._u_r_1.id)
+        self.assertEqual(examples.count(), 1)


### PR DESCRIPTION
# [introduction and acknowledgement]

prior to this pull request,
one test case was intentionally marked as "to be skipped by the `unittest` framework"
because it was in a FAILing state and the reason for that was unclear to me

the reason was explained to me by Miguel Grinberg,
and he also proposed several approaches for rectifying the problem

---

# [background: what specific problem does this pull request rectify?]

when running the backend application in development mode
against a MySQL database,
the backend (or, more specifically, the database engine) prevents the deletion of a `User` resource,
associated with which there exists at least one resource (in another database model);
however,
running the `Test_06_DeleteUserHavingResources.test_1_prevent_deletion` test case,
which is backed by an in-memory SQLite database,
does not prevent the deletion of an analogous `User` resource

---

in addition to the core changes that were already described in this section,
this pull request also:

  - fixes a bug in `backend/scripts/script_2023_03_19_15_30_delete_users_that_have_not_been_confirmed_yet.py`

  - makes updates to `README.md`,
    which, ideally, should have been made
    as part of the pull request at https://github.com/kaloyan-marinov/vocab-treasury/pull/32

---

# [analysis]

basically, the problem is that
the implementation of the handler for `DELETE /api/users/<int:user_id>` requests
is assuming/hoping that
all database engines have exactly the same behavior;
however, SQLite in particular does not enforce all existing standards;
the observed behavior, which was described in the previous section, appears to indicate that
SQLite does not enforce referential integrity (for foreign keys);

to take the analysis one step further:
part of the backend application (= the handler for `DELETE /api/users/<int:user_id>`)
is currently implemented with a specific database in mind,
which means that

  - EITHER the unit test for the handler in question should be backed by the same database,

  - OR the application/handler should be modified in order to render it/them "database-agnostic";

my preference is to do the latter

---

# [possible approaches]

even with the preference expressed in the previous section,
multiple approaches are possible - such as:

(Approach 1):

make the `delete_users` handler
begin by deleting all `Examples` and `EmailAddressChanges` associated with the targeted `User`
and only then go on to delete the targeted `User`

(Approach 2):

augment the `User` model with a `marked_for_deletion` field
which defaults to `False`
and which gets changed to `True` within the `delete_users` function;
then, ask a background thread (or a Celery worker) to perform the actions from (Approach 1);
(
that would require changing the `verify_password` function at
https://github.com/kaloyan-marinov/vocab-treasury/blob/c487d933849f9800f03e9b41bc955311aab8a74b/backend/src/auth.py#L13-L38
from
```
# ...
if user is None:
    None
# ...
```
to
```
# ...
if user is None or user.marked_for_deletion is True:
    return None
# ...

)
```

(Approach 3):

let SQLAlchemy validate things for us

if we add relationship attributes to the `User` model,
then SQLAlchemy will try to set each foreign key to `NULL` before a `User` entity is deleted;

importantly,
if the database itself has imposed a non-nullable constraint
on the foreign key (in the related model) on the other side of each relationship,
then attempting to delete a `User` object,
associated with which there exists at least one resource (in another database model),
will fail

(
this should be a more "database-agnostic" (= robust) option,
because it is unlikely that
any database engine allows a non-nullable column to be set to `NULL`
)

(Approach 4):

still using relationship attributes,
we can change the behavior to delete the linked entities instead of clearing the foreign key

---

(Approach 3) and (Approach 4):

  - were proposed by Miguel Grinberg

  - are all implemented/ensured/managed by SQLAlchemy
    without relying on any database `CASCADE`s

---

# [decision]

each of (Approach 3) and (Approach 4) was empirically verified to work
as described in the previous section

this pull request implements (Approach 3)

(
for future reference,
(Approach 4) can be implemented by

(a) checking out commit `d878cbe9218ddda20655b1e238398b15cce01b8c`, and

(b) uncommenting the lines at
    https://github.com/kaloyan-marinov/vocab-treasury/blob/d878cbe9218ddda20655b1e238398b15cce01b8c/backend/src/models.py#L67
    and
    https://github.com/kaloyan-marinov/vocab-treasury/blob/d878cbe9218ddda20655b1e238398b15cce01b8c/backend/src/models.py#L73
)
