### PR TITLE
Enable every newly-created user to confirm their email address through the frontend

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,38 +6,32 @@
   "configurations": [
     {
       "name": "[new way] Python: Flask",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "cwd": "${workspaceFolder}/backend",
       "module": "flask",
       "env": {
         "FLASK_APP": "src",
-        // TODO: (2024/03/15, 05:57)
-        //       update the following line
-        //       according to the following deprecation warning:
-        //       ```
-        //       'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.
-        //       ```
-        "FLASK_ENV": "development"
+        "FLASK_DEBUG": "True"
       },
       "args": ["run", "--no-debugger"],
       "jinja": true
     },
     {
       "name": "[old way] Python: Flask",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "cwd": "${workspaceFolder}/backend",
       "module": "run_dev_server",
       "env": {
-        "FLASK_ENV": "development"
+        "FLASK_DEBUG": "True"
       },
       "jinja": true,
       "justMyCode": false
     },
     {
       "name": "Python: Current File",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "env": {
         "CONFIGURATION_4_BACKEND": "development",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,12 @@
       "module": "flask",
       "env": {
         "FLASK_APP": "src",
+        // TODO: (2024/03/15, 05:57)
+        //       update the following line
+        //       according to the following deprecation warning:
+        //       ```
+        //       'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.
+        //       ```
         "FLASK_ENV": "development"
       },
       "args": ["run", "--no-debugger"],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,6 @@
     
     "jest.rootPath": "frontend",
     "jest.jestCommandLine": "npm run test --",
-    "jest.autoRun": "off" //,
-    // "jest.runMode": "on-demand"
+    // "jest.autoRun": "off" //,
+    "jest.runMode": "on-demand"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,10 +21,14 @@
       "editor.formatOnSave": true
     },
 
-    // Controls if suggestions should be accepted 'Enter' - in addition to 'Tab'.
+    // Controls if suggestions should be accepted the 'Enter' key
+    // - in addition to via the 'Tab' key.
     // Helps to avoid ambiguity between inserting new lines or accepting suggestions.
     "editor.acceptSuggestionOnEnter": "off",
+    // Controls if suggestions should be accepted via the ';' and ')' keys
+    // - in addition to via the 'Tab' key.
     "editor.acceptSuggestionOnCommitCharacter": false,
+
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
@@ -36,6 +40,5 @@
     
     "jest.rootPath": "frontend",
     "jest.jestCommandLine": "npm run test --",
-    // "jest.autoRun": "off" //,
     "jest.runMode": "on-demand"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
     // Controls if suggestions should be accepted 'Enter' - in addition to 'Tab'.
     // Helps to avoid ambiguity between inserting new lines or accepting suggestions.
     "editor.acceptSuggestionOnEnter": "off",
+    "editor.acceptSuggestionOnCommitCharacter": false,
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ and use `localhost` to serve a frontend application.
 
 # Future plans
 
-- enable every newly-created user to confirm their email address
+- enable every newly-created user to reset their password
   through the frontend
 
 - allow each user to export their personal data in JSON format

--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -480,6 +480,11 @@ def send_email_requesting_that_email_address_should_be_confirmed(user):
         current_app.config["SECRET_KEY"],
         algorithm="HS256",
     )
+    link_to_frontend_for_email_address_confirmation = url_for(
+        "api_blueprint.confirm_email_address",
+        token=email_address_confirmation_token,
+        _external=True,
+    ).replace("localhost:5000/api", "localhost:3000")
 
     msg_sender = current_app.config["ADMINS"][0]
     msg_recipients = [user.email]
@@ -493,19 +498,10 @@ Please confirm your email address
 in order to be able to log in and start using VocabTreasury.
 
 To confirm your email address,
-launch a terminal instance and issue the following request:
-```
-$ curl \\
-    -i \\
-    -L \\
-    -H "Content-Type: application/json" \\
-    -X POST \\
-    {url_for(
-        'api_blueprint.confirm_email_address',
-        token=email_address_confirmation_token,
-        _external=True,
-    )}
-```
+open the following link in your web browser
+and click on the 'Confirm my email address' button:
+
+{link_to_frontend_for_email_address_confirmation}
 
 Sincerely,
 The VocabTreasury Team

--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -8,6 +8,8 @@ import sqlalchemy
 import datetime as dt
 import jwt
 
+import os
+
 from src import db, flsk_bcrpt, mail
 from src.models import User, EmailAddressChange
 from src.auth import basic_auth, token_auth, validate_token
@@ -480,14 +482,26 @@ def send_email_requesting_that_email_address_should_be_confirmed(user):
         current_app.config["SECRET_KEY"],
         algorithm="HS256",
     )
+
     link_to_backend_for_email_address_confirmation = url_for(
         "api_blueprint.confirm_email_address",
         token=email_address_confirmation_token,
         _external=True,
     )
-    link_to_frontend_for_email_address_confirmation = (
-        link_to_backend_for_email_address_confirmation.replace(":5000/api/", ":3000/")
-    )
+    if os.environ.get("CONFIGURATION_4_BACKEND") == "development":
+        link_to_frontend_for_email_address_confirmation = (
+            link_to_backend_for_email_address_confirmation.replace(
+                ":5000/api/",
+                ":3000/",
+            )
+        )
+    else:
+        link_to_frontend_for_email_address_confirmation = (
+            link_to_backend_for_email_address_confirmation.replace(
+                "/api/",
+                "/",
+            )
+        )
 
     msg_sender = current_app.config["ADMINS"][0]
     msg_recipients = [user.email]

--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -480,11 +480,14 @@ def send_email_requesting_that_email_address_should_be_confirmed(user):
         current_app.config["SECRET_KEY"],
         algorithm="HS256",
     )
-    link_to_frontend_for_email_address_confirmation = url_for(
+    link_to_backend_for_email_address_confirmation = url_for(
         "api_blueprint.confirm_email_address",
         token=email_address_confirmation_token,
         _external=True,
-    ).replace("localhost:5000/api", "localhost:3000")
+    )
+    link_to_frontend_for_email_address_confirmation = (
+        link_to_backend_for_email_address_confirmation.replace(":5000/api/", ":3000/")
+    )
 
     msg_sender = current_app.config["ADMINS"][0]
     msg_recipients = [user.email]

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -306,93 +306,101 @@ test(
   }
 );
 
-test("a newly-created user confirms their email address", async () => {
-  /* Arrange. */
-  requestInterceptionLayer.use(
-    rest.post(
-      "/api/confirm-email-address/:token_for_confirming_email_address",
-      (req, res, ctx) => {
-        return res.once(
-          ctx.status(200),
-          ctx.json({
-            message:
-              "[mocked] You have confirmed your email address successfully." +
-              " You may now log in.",
-          })
-        );
-      }
-    )
-  );
+test(
+  "a newly-created user clicks the button for confirming their email address" +
+    " and the request is processed succesfully by the backend",
+  async () => {
+    /* Arrange. */
+    requestInterceptionLayer.use(
+      rest.post(
+        "/api/confirm-email-address/:token_for_confirming_email_address",
+        (req, res, ctx) => {
+          return res.once(
+            ctx.status(200),
+            ctx.json({
+              message:
+                "[mocked] You have confirmed your email address successfully." +
+                " You may now log in.",
+            })
+          );
+        }
+      )
+    );
 
-  const realStore = createStore(rootReducer, enhancer);
+    const realStore = createStore(rootReducer, enhancer);
 
-  render(
-    <Provider store={realStore}>
-      <Router history={history}>
-        <App />
-      </Router>
-    </Provider>
-  );
+    render(
+      <Provider store={realStore}>
+        <Router history={history}>
+          <App />
+        </Router>
+      </Provider>
+    );
 
-  /* Act. */
-  const tokenForConfirmingEmailAddress =
-    "mocked-correct-token-for-confirming-email-address";
-  history.push(`/confirm-email-address/${tokenForConfirmingEmailAddress}`);
+    /* Act. */
+    const tokenForConfirmingEmailAddress =
+      "mocked-correct-token-for-confirming-email-address";
+    history.push(`/confirm-email-address/${tokenForConfirmingEmailAddress}`);
 
-  const confirmEmailAddressButton = screen.getByRole("button", {
-    name: "Confirm my email address",
-  });
-  fireEvent.click(confirmEmailAddressButton);
+    const confirmEmailAddressButton = screen.getByRole("button", {
+      name: "Confirm my email address",
+    });
+    fireEvent.click(confirmEmailAddressButton);
 
-  /* Assert. */
-  const temp = await screen.findByText(
-    "EMAIL-ADDRESS CONFIRMATION SUCCESSFUL - YOU MAY NOW LOG IN."
-  );
-  expect(temp).toBeInTheDocument();
-});
+    /* Assert. */
+    const temp = await screen.findByText(
+      "EMAIL-ADDRESS CONFIRMATION SUCCESSFUL - YOU MAY NOW LOG IN."
+    );
+    expect(temp).toBeInTheDocument();
+  }
+);
 
-test("a newly-created user attempts to confirm their email address", async () => {
-  /* Arrange. */
-  const mockSingleFailure = createMockOneOrManyFailures("single failure", {
-    statusCode: 401,
-    error: "[mocked] Unauthorized,",
-    message: "[mocked] The provided token is invalid.",
-  });
-  requestInterceptionLayer.use(
-    rest.post(
-      "/api/confirm-email-address/:token_for_confirming_email_address",
-      mockSingleFailure
-    )
-  );
+test(
+  "a newly-created user clicks the button for confirming their email address" +
+    " but the request is rejected by the backend",
+  async () => {
+    /* Arrange. */
+    const mockSingleFailure = createMockOneOrManyFailures("single failure", {
+      statusCode: 401,
+      error: "[mocked] Unauthorized,",
+      message: "[mocked] The provided token is invalid.",
+    });
+    requestInterceptionLayer.use(
+      rest.post(
+        "/api/confirm-email-address/:token_for_confirming_email_address",
+        mockSingleFailure
+      )
+    );
 
-  const realStore = createStore(rootReducer, enhancer);
+    const realStore = createStore(rootReducer, enhancer);
 
-  render(
-    <Provider store={realStore}>
-      <Router history={history}>
-        <App />
-      </Router>
-    </Provider>
-  );
+    render(
+      <Provider store={realStore}>
+        <Router history={history}>
+          <App />
+        </Router>
+      </Provider>
+    );
 
-  /* Act. */
-  const tokenForConfirmingEmailAddress =
-    "mocked-incorrect-token-for-confirming-email-address";
-  history.push(`/confirm-email-address/${tokenForConfirmingEmailAddress}`);
+    /* Act. */
+    const tokenForConfirmingEmailAddress =
+      "mocked-incorrect-token-for-confirming-email-address";
+    history.push(`/confirm-email-address/${tokenForConfirmingEmailAddress}`);
 
-  const confirmMyEmailAddressButton = screen.getByRole("button", {
-    name: "Confirm my email address",
-  });
-  fireEvent.click(confirmMyEmailAddressButton);
+    const confirmMyEmailAddressButton = screen.getByRole("button", {
+      name: "Confirm my email address",
+    });
+    fireEvent.click(confirmMyEmailAddressButton);
 
-  /* Assert. */
-  const temp = await screen.findByText(
-    "[mocked] The provided token is invalid." +
-      " PLEASE DOUBLE-CHECK YOUR EMAIL INBOX FOR A MESSAGE" +
-      " WITH INSTRUCTIONS ON HOW TO CONFIRM YOUR EMAIL ADDRESS."
-  );
-  expect(temp).toBeInTheDocument();
-});
+    /* Assert. */
+    const temp = await screen.findByText(
+      "[mocked] The provided token is invalid." +
+        " PLEASE DOUBLE-CHECK YOUR EMAIL INBOX FOR A MESSAGE" +
+        " WITH INSTRUCTIONS ON HOW TO CONFIRM YOUR EMAIL ADDRESS."
+    );
+    expect(temp).toBeInTheDocument();
+  }
+);
 
 test("the user clicks the navigation-controlling button for 'Next page'", async () => {
   /* Arrange. */

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -31,12 +31,11 @@ import { App } from "./App";
 // jest.setTimeout(BIG_VALUE_FOR_TIMEOUT_OF_ASYNCHRONOUS_OPERATIONS);
 
 /* Create an MSW "request-interception layer". */
-const mockMultipleFailures = createMockOneOrManyFailures(
-  "multiple failures",
-  401,
-  "[mocked] Unauthorized",
-  "[mocked] Authentication in the Basic Auth format is required."
-);
+const mockMultipleFailures = createMockOneOrManyFailures("multiple failures", {
+  statusCode: 401,
+  error: "[mocked] Unauthorized",
+  message: "[mocked] Authentication in the Basic Auth format is required.",
+});
 const requestHandlersToMock = [
   rest.post("/api/users", mockMultipleFailures),
 
@@ -95,12 +94,12 @@ test(
     requestInterceptionLayer.use(
       rest.get(
         "/api/user-profile",
-        createMockOneOrManyFailures(
-          "single failure",
-          401,
-          "[mocked] Unauthorized",
-          "[mocked] Authentication in the Basic Auth format is required."
-        )
+        createMockOneOrManyFailures("single failure", {
+          statusCode: 401,
+          error: "[mocked] Unauthorized",
+          message:
+            "[mocked] Authentication in the Basic Auth format is required.",
+        })
       ),
 
       rest.post("/api/tokens", requestHandlers.mockIssueJWSToken),
@@ -360,12 +359,11 @@ test("a newly-created user attempts to confirm their email address", async () =>
   requestInterceptionLayer.use(
     rest.post(
       "/api/confirm-email-address/:token_for_confirming_email_address",
-      createMockOneOrManyFailures(
-        "single failure",
-        401,
-        "[mocked] Unauthorized,",
-        "[mocked] The provided token is invalid."
-      )
+      createMockOneOrManyFailures("single failure", {
+        statusCode: 401,
+        error: "[mocked] Unauthorized,",
+        message: "[mocked] The provided token is invalid.",
+      })
     )
   );
 
@@ -1146,12 +1144,12 @@ test(
 
       rest.delete(
         "/api/examples/:id",
-        createMockOneOrManyFailures(
-          "single failure",
-          401,
-          "[mocked] Unauthorized",
-          "[mocked] Authentication in the Basic Auth format is required."
-        )
+        createMockOneOrManyFailures("single failure", {
+          statusCode: 401,
+          error: "[mocked] Unauthorized",
+          message:
+            "[mocked] Authentication in the Basic Auth format is required.",
+        })
       )
     );
 
@@ -1372,12 +1370,12 @@ test(
 
       rest.put(
         "/api/examples/:id",
-        createMockOneOrManyFailures(
-          "single failure",
-          401,
-          "[mocked] Unauthorized",
-          "[mocked] Authentication in the Basic Auth format is required."
-        )
+        createMockOneOrManyFailures("single failure", {
+          statusCode: 401,
+          error: "[mocked] Unauthorized",
+          message:
+            "[mocked] Authentication in the Basic Auth format is required.",
+        })
       )
     );
 
@@ -1506,12 +1504,12 @@ test(
 
       rest.get(
         "/api/examples",
-        createMockOneOrManyFailures(
-          "single failure",
-          401,
-          "[mocked] Unauthorized",
-          "[mocked] Authentication in the Basic Auth format is required."
-        )
+        createMockOneOrManyFailures("single failure", {
+          statusCode: 401,
+          error: "[mocked] Unauthorized",
+          message:
+            "[mocked] Authentication in the Basic Auth format is required.",
+        })
       )
     );
 
@@ -1610,12 +1608,12 @@ test(
     requestInterceptionLayer.use(
       rest.get(
         "/api/user-profile",
-        createMockOneOrManyFailures(
-          "single failure",
-          401,
-          "[mocked] Unauthorized",
-          "[mocked] Authentication in the Basic Auth format is required."
-        )
+        createMockOneOrManyFailures("single failure", {
+          statusCode: 401,
+          error: "[mocked] Unauthorized",
+          message:
+            "[mocked] Authentication in the Basic Auth format is required.",
+        })
       ),
       rest.post(
         "/api/request-password-reset",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1542,7 +1542,7 @@ test(
 
 test(
   "if a logged-in user manually changes" +
-    " the URL in her browser's address bar to /request_password_reset ," +
+    " the URL in her browser's address bar to /request-password-reset ," +
     " the frontend application should redirect the user to /home",
   async () => {
     /* Arrange. */
@@ -1569,7 +1569,7 @@ test(
 
     /* Act. */
     /* Simulate the user's manually changing the URL in her browser's address bar. */
-    history.push("/request_password_reset");
+    history.push("/request-password-reset");
 
     /* Assert. */
     expect(history.location.pathname).toEqual("/home");

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1677,3 +1677,42 @@ test(
     expect(history.location.pathname).toEqual("/home");
   }
 );
+
+test(
+  "if a logged-in user manually changes" +
+    " the URL in her browser's address bar to" +
+    " /confirm-email-address/let-us-pretend-this-part-is-a-valid-token ," +
+    " the frontend application should redirect the user to /home",
+  async () => {
+    /* Arrange. */
+    const realStore = createStore(rootReducer, enhancer);
+
+    requestInterceptionLayer.use(
+      rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile)
+    );
+
+    render(
+      <Provider store={realStore}>
+        <Router history={history}>
+          <App />
+        </Router>
+      </Provider>
+    );
+
+    let temp: HTMLElement;
+
+    temp = await screen.findByText("Log out");
+    expect(temp).toBeInTheDocument();
+
+    expect(history.location.pathname).toEqual("/");
+
+    /* Act. */
+    /* Simulate the user's manually changing the URL in her browser's address bar. */
+    history.push(
+      "/confirm-email-address/let-us-pretend-this-part-is-a-valid-token"
+    );
+
+    /* Assert. */
+    expect(history.location.pathname).toEqual("/home");
+  }
+);

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -91,16 +91,13 @@ test(
     /* Arrange. */
     const realStore = createStore(rootReducer, initState, enhancer);
 
+    const mockSingleFailure = createMockOneOrManyFailures("single failure", {
+      statusCode: 401,
+      error: "[mocked] Unauthorized",
+      message: "[mocked] Authentication in the Basic Auth format is required.",
+    });
     requestInterceptionLayer.use(
-      rest.get(
-        "/api/user-profile",
-        createMockOneOrManyFailures("single failure", {
-          statusCode: 401,
-          error: "[mocked] Unauthorized",
-          message:
-            "[mocked] Authentication in the Basic Auth format is required.",
-        })
-      ),
+      rest.get("/api/user-profile", mockSingleFailure),
 
       rest.post("/api/tokens", requestHandlers.mockIssueJWSToken),
       rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile),
@@ -356,14 +353,15 @@ test("a newly-created user confirms their email address", async () => {
 
 test("a newly-created user attempts to confirm their email address", async () => {
   /* Arrange. */
+  const mockSingleFailure = createMockOneOrManyFailures("single failure", {
+    statusCode: 401,
+    error: "[mocked] Unauthorized,",
+    message: "[mocked] The provided token is invalid.",
+  });
   requestInterceptionLayer.use(
     rest.post(
       "/api/confirm-email-address/:token_for_confirming_email_address",
-      createMockOneOrManyFailures("single failure", {
-        statusCode: 401,
-        error: "[mocked] Unauthorized,",
-        message: "[mocked] The provided token is invalid.",
-      })
+      mockSingleFailure
     )
   );
 
@@ -1137,20 +1135,17 @@ test(
     const realStore = createStore(rootReducer, enhancer);
 
     const rhf: RequestHandlingFacilitator = new RequestHandlingFacilitator();
+    const mockSingleFailure = createMockOneOrManyFailures("single failure", {
+      statusCode: 401,
+      error: "[mocked] Unauthorized",
+      message: "[mocked] Authentication in the Basic Auth format is required.",
+    });
     requestInterceptionLayer.use(
       rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile),
 
       rest.get("/api/examples", rhf.createMockFetchExamples()),
 
-      rest.delete(
-        "/api/examples/:id",
-        createMockOneOrManyFailures("single failure", {
-          statusCode: 401,
-          error: "[mocked] Unauthorized",
-          message:
-            "[mocked] Authentication in the Basic Auth format is required.",
-        })
-      )
+      rest.delete("/api/examples/:id", mockSingleFailure)
     );
 
     render(
@@ -1362,21 +1357,17 @@ test(
     const realStore = createStore(rootReducer, enhancer);
 
     const rhf: RequestHandlingFacilitator = new RequestHandlingFacilitator();
-
+    const mockSingleFailure = createMockOneOrManyFailures("single failure", {
+      statusCode: 401,
+      error: "[mocked] Unauthorized",
+      message: "[mocked] Authentication in the Basic Auth format is required.",
+    });
     requestInterceptionLayer.use(
       rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile),
 
       rest.get("/api/examples", rhf.createMockFetchExamples()),
 
-      rest.put(
-        "/api/examples/:id",
-        createMockOneOrManyFailures("single failure", {
-          statusCode: 401,
-          error: "[mocked] Unauthorized",
-          message:
-            "[mocked] Authentication in the Basic Auth format is required.",
-        })
-      )
+      rest.put("/api/examples/:id", mockSingleFailure)
     );
 
     render(
@@ -1497,20 +1488,17 @@ test(
     const realStore = createStore(rootReducer, enhancer);
 
     const rhf: RequestHandlingFacilitator = new RequestHandlingFacilitator();
+    const mockSingleFailure = createMockOneOrManyFailures("single failure", {
+      statusCode: 401,
+      error: "[mocked] Unauthorized",
+      message: "[mocked] Authentication in the Basic Auth format is required.",
+    });
     requestInterceptionLayer.use(
       rest.get("/api/user-profile", requestHandlers.mockFetchUserProfile),
 
       rest.get("/api/examples", rhf.createMockFetchExamples()),
 
-      rest.get(
-        "/api/examples",
-        createMockOneOrManyFailures("single failure", {
-          statusCode: 401,
-          error: "[mocked] Unauthorized",
-          message:
-            "[mocked] Authentication in the Basic Auth format is required.",
-        })
-      )
+      rest.get("/api/examples", mockSingleFailure)
     );
 
     render(
@@ -1605,16 +1593,13 @@ test(
     " an alert should be created",
   async () => {
     /* Arrange. */
+    const mockSingleFailure = createMockOneOrManyFailures("single failure", {
+      statusCode: 401,
+      error: "[mocked] Unauthorized",
+      message: "[mocked] Authentication in the Basic Auth format is required.",
+    });
     requestInterceptionLayer.use(
-      rest.get(
-        "/api/user-profile",
-        createMockOneOrManyFailures("single failure", {
-          statusCode: 401,
-          error: "[mocked] Unauthorized",
-          message:
-            "[mocked] Authentication in the Basic Auth format is required.",
-        })
-      ),
+      rest.get("/api/user-profile", mockSingleFailure),
       rest.post(
         "/api/request-password-reset",
         requestHandlers.mockRequestPasswordReset

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -11,7 +11,7 @@ import { createStore, applyMiddleware } from "redux";
 import { Provider } from "react-redux";
 import { createMemoryHistory, MemoryHistory } from "history";
 import { Router } from "react-router-dom";
-import { rest, RestRequest } from "msw";
+import { rest } from "msw";
 import { setupServer, SetupServerApi } from "msw/node";
 import thunkMiddleware from "redux-thunk";
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { NavigationBar } from "./features/NavigationBar";
 import { About } from "./features/About";
 import { Account } from "./features/Account";
 import { Register } from "./features/auth/Register";
+import { ConfirmEmailAddress } from "./features/auth/ConfirmEmailAddress";
 import { Login } from "./features/auth/Login";
 import { RequestPasswordReset } from "./features/auth/RequestPasswordReset";
 import { fetchProfile } from "./features/auth/authSlice";
@@ -63,10 +64,16 @@ export const App = () => {
         <Route exact path="/register">
           <Register />
         </Route>
+        <Route
+          exact
+          path="/confirm-email-address/:token_for_confirming_email_address"
+        >
+          <ConfirmEmailAddress />
+        </Route>
         <Route exact path="/login">
           <Login />
         </Route>
-        <Route exact path="/request_password_reset">
+        <Route exact path="/request-password-reset">
           <RequestPasswordReset />
         </Route>
         <PrivateRoute exact path="/account">

--- a/frontend/src/features/alerts/alertsSlice.ts
+++ b/frontend/src/features/alerts/alertsSlice.ts
@@ -51,10 +51,10 @@ export const alertsReducer = (
       // For the sake of keeping track of mistakes,
       // the commented-out code-block below contains a mistake.
       /*
-        const newState: IStateAlerts = { ...state };
-        newState.ids.push(alert.id);
-        newState.entities[alert.id] = alert;
-        */
+      const newState: IStateAlerts = { ...state };
+      newState.ids.push(alert.id);
+      newState.entities[alert.id] = alert;
+      */
 
       // The following code-block fixes the commented-out code-block's mistake.
       const newAlertsIds: string[] = [alert.id, ...state.ids];

--- a/frontend/src/features/auth/ConfirmEmailAddress.tsx
+++ b/frontend/src/features/auth/ConfirmEmailAddress.tsx
@@ -47,16 +47,12 @@ export const ConfirmEmailAddress = () => {
         pathname: "/login",
       };
       history.push(locationDescriptor);
-    } catch (err) {
-      if (err.response.status == 401) {
-        const message =
-          err.response.data.message +
-          " PLEASE DOUBLE-CHECK YOUR EMAIL INBOX FOR A MESSAGE" +
-          " WITH INSTRUCTIONS ON HOW TO CONFIRM YOUR EMAIL ADDRESS.";
-        dispatch(alertsCreate(id, message));
-      } else {
-        dispatch(alertsCreate(id, "UNKNOWN ERROR ENCOUNTERED"));
-      }
+    } catch (thunkActionError) {
+      const message =
+        thunkActionError +
+        " PLEASE DOUBLE-CHECK YOUR EMAIL INBOX FOR A MESSAGE" +
+        " WITH INSTRUCTIONS ON HOW TO CONFIRM YOUR EMAIL ADDRESS.";
+      dispatch(alertsCreate(id, message));
     }
   };
 

--- a/frontend/src/features/auth/ConfirmEmailAddress.tsx
+++ b/frontend/src/features/auth/ConfirmEmailAddress.tsx
@@ -1,0 +1,22 @@
+import { useParams } from "react-router-dom";
+
+export const ConfirmEmailAddress = () => {
+  console.log(
+    `${new Date().toISOString()} - React is rendering <ConfirmEmailAddress>`
+  );
+
+  const params: { token_for_confirming_email_address: string } = useParams();
+  console.log(
+    `${new Date().toISOString()} - inspecting the \`params\` passed in to <ConfirmEmailAddress>`
+  );
+
+  return (
+    <>
+      {process.env.NODE_ENV === "development" && "<ConfirmEmailAddress>"}
+      <div className="mx-auto col-md-6">
+        token_for_confirming_email_address:{" "}
+        {params.token_for_confirming_email_address}
+      </div>
+    </>
+  );
+};

--- a/frontend/src/features/auth/ConfirmEmailAddress.tsx
+++ b/frontend/src/features/auth/ConfirmEmailAddress.tsx
@@ -18,6 +18,9 @@ export const ConfirmEmailAddress = () => {
   console.log(
     `${new Date().toISOString()} - inspecting the \`params\` passed in to <ConfirmEmailAddress>`
   );
+  console.log(params);
+  const tokenForConfirmingEmailAddress: string =
+    params.token_for_confirming_email_address;
 
   const hasValidToken: boolean | null = useSelector(selectHasValidToken);
   console.log(`    hasValidToken: ${hasValidToken}`);
@@ -52,9 +55,7 @@ export const ConfirmEmailAddress = () => {
 
     const id: string = uuidv4();
     try {
-      await dispatch(
-        confirmEmailAddress(params.token_for_confirming_email_address)
-      );
+      await dispatch(confirmEmailAddress(tokenForConfirmingEmailAddress));
 
       dispatch(
         alertsCreate(

--- a/frontend/src/features/auth/ConfirmEmailAddress.tsx
+++ b/frontend/src/features/auth/ConfirmEmailAddress.tsx
@@ -57,14 +57,16 @@ export const ConfirmEmailAddress = () => {
   };
 
   return (
-    <>
-      {process.env.NODE_ENV === "development" && "<ConfirmEmailAddress>"}
+    <div className="mx-auto w-50 d-grid">
+      {process.env.NODE_ENV === "development" && (
+        <p>&lt; ConfirmEmailAddress &gt;</p>
+      )}
       <button
         onClick={(e: React.MouseEvent<HTMLButtonElement>) => handleClick(e)}
         className="btn btn-primary"
       >
         Confirm my email address
       </button>
-    </>
+    </div>
   );
 };

--- a/frontend/src/features/auth/ConfirmEmailAddress.tsx
+++ b/frontend/src/features/auth/ConfirmEmailAddress.tsx
@@ -36,6 +36,13 @@ export const ConfirmEmailAddress = () => {
       `    hasValidToken: ${hasValidToken} > redirecting to ${nextURL} ...`
     );
     return <Redirect to={nextURL} />;
+    /*
+    It is interesting to note that
+    it is possible to replace the following statement with
+    ```
+    history.push(nextURL);
+    ```
+    */
   }
 
   const handleClick = async (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/frontend/src/features/auth/ConfirmEmailAddress.tsx
+++ b/frontend/src/features/auth/ConfirmEmailAddress.tsx
@@ -1,9 +1,11 @@
 import { useParams, useHistory } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
-import { useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { ThunkDispatch } from "redux-thunk";
+import { Redirect } from "react-router-dom";
 
 import { IState } from "../../types";
+import { selectHasValidToken } from "../../store";
 import { IActionAlertsCreate, alertsCreate } from "../alerts/alertsSlice";
 import { ActionConfirmEmailAddress, confirmEmailAddress } from "./authSlice";
 
@@ -17,6 +19,9 @@ export const ConfirmEmailAddress = () => {
     `${new Date().toISOString()} - inspecting the \`params\` passed in to <ConfirmEmailAddress>`
   );
 
+  const hasValidToken: boolean | null = useSelector(selectHasValidToken);
+  console.log(`    hasValidToken: ${hasValidToken}`);
+
   const history = useHistory();
 
   const dispatch: ThunkDispatch<
@@ -24,6 +29,14 @@ export const ConfirmEmailAddress = () => {
     unknown,
     IActionAlertsCreate | ActionConfirmEmailAddress
   > = useDispatch();
+
+  if (hasValidToken === true) {
+    const nextURL: string = "/home";
+    console.log(
+      `    hasValidToken: ${hasValidToken} > redirecting to ${nextURL} ...`
+    );
+    return <Redirect to={nextURL} />;
+  }
 
   const handleClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();

--- a/frontend/src/features/auth/Login.test.tsx
+++ b/frontend/src/features/auth/Login.test.tsx
@@ -173,7 +173,15 @@ describe("multiple components + mocking of HTTP requests to the backend", () => 
       const realStore = createStore(rootReducer, enhancer);
 
       requestInterceptionLayer.use(
-        rest.post("/api/tokens", createMockOneOrManyFailures("single failure"))
+        rest.post(
+          "/api/tokens",
+          createMockOneOrManyFailures(
+            "single failure",
+            401,
+            "[mocked] Unauthorized",
+            "[mocked] Authentication in the Basic Auth format is required."
+          )
+        )
       );
 
       render(

--- a/frontend/src/features/auth/Login.test.tsx
+++ b/frontend/src/features/auth/Login.test.tsx
@@ -175,12 +175,12 @@ describe("multiple components + mocking of HTTP requests to the backend", () => 
       requestInterceptionLayer.use(
         rest.post(
           "/api/tokens",
-          createMockOneOrManyFailures(
-            "single failure",
-            401,
-            "[mocked] Unauthorized",
-            "[mocked] Authentication in the Basic Auth format is required."
-          )
+          createMockOneOrManyFailures("single failure", {
+            statusCode: 401,
+            error: "[mocked] Unauthorized",
+            message:
+              "[mocked] Authentication in the Basic Auth format is required.",
+          })
         )
       );
 

--- a/frontend/src/features/auth/Login.test.tsx
+++ b/frontend/src/features/auth/Login.test.tsx
@@ -172,17 +172,13 @@ describe("multiple components + mocking of HTTP requests to the backend", () => 
       /* Arrange. */
       const realStore = createStore(rootReducer, enhancer);
 
-      requestInterceptionLayer.use(
-        rest.post(
-          "/api/tokens",
-          createMockOneOrManyFailures("single failure", {
-            statusCode: 401,
-            error: "[mocked] Unauthorized",
-            message:
-              "[mocked] Authentication in the Basic Auth format is required.",
-          })
-        )
-      );
+      const mockSingleFailure = createMockOneOrManyFailures("single failure", {
+        statusCode: 401,
+        error: "[mocked] Unauthorized",
+        message:
+          "[mocked] Authentication in the Basic Auth format is required.",
+      });
+      requestInterceptionLayer.use(rest.post("/api/tokens", mockSingleFailure));
 
       render(
         <Provider store={realStore}>

--- a/frontend/src/features/auth/Login.tsx
+++ b/frontend/src/features/auth/Login.tsx
@@ -112,7 +112,7 @@ export const Login = () => {
         </form>
         <hr />
         <div className="d-grid">
-          <Link to="/request_password_reset" className="btn btn-dark mt-2">
+          <Link to="/request-password-reset" className="btn btn-dark mt-2">
             FORGOT PASSWORD?
           </Link>
         </div>

--- a/frontend/src/features/auth/RequestPasswordReset.tsx
+++ b/frontend/src/features/auth/RequestPasswordReset.tsx
@@ -25,10 +25,6 @@ export const RequestPasswordReset = () => {
     ActionRequestPasswordReset | IActionAlertsCreate
   > = useDispatch();
 
-  /*
-  TODO: (2024/03/14, 13:47)
-        consider incorporating this same logic into `<ConfirmEmailAddress>`
-  */
   if (hasValidToken === true) {
     const nextURL: string = "/home";
     console.log(

--- a/frontend/src/features/auth/RequestPasswordReset.tsx
+++ b/frontend/src/features/auth/RequestPasswordReset.tsx
@@ -25,6 +25,10 @@ export const RequestPasswordReset = () => {
     ActionRequestPasswordReset | IActionAlertsCreate
   > = useDispatch();
 
+  /*
+  TODO: (2024/03/14, 13:47)
+        consider incorporating this same logic into `<ConfirmEmailAddress>`
+  */
   if (hasValidToken === true) {
     const nextURL: string = "/home";
     console.log(

--- a/frontend/src/features/auth/authSlice.test.ts
+++ b/frontend/src/features/auth/authSlice.test.ts
@@ -8,7 +8,10 @@ import { AnyAction } from "redux";
 import { RequestStatus, IProfile, IStateAuth, IState } from "../../types";
 import { INITIAL_STATE_AUTH, VOCAB_TREASURY_APP_TOKEN } from "../../constants";
 import { MOCK_PROFILE } from "../../mockPiecesOfData";
-import { requestHandlers } from "../../testHelpers";
+import {
+  requestHandlers,
+  createMockOneOrManyFailures,
+} from "../../testHelpers";
 import { logOut, INITIAL_STATE } from "../../store";
 import {
   ActionTypesCreateUser,
@@ -799,18 +802,18 @@ describe(
         " + the HTTP request issued by that thunk-action is mocked to fail",
       async () => {
         /* Arrange. */
+        const mockSingleFailure = createMockOneOrManyFailures(
+          "single failure",
+          {
+            statusCode: 401,
+            error: "[mocked] Unauthorized,",
+            message: "[mocked] The provided token is invalid.",
+          }
+        );
         requestInterceptionLayer.use(
           rest.post(
             "/api/confirm-email-address/:token_for_confirming_email_address",
-            (req, res, ctx) => {
-              return res(
-                ctx.status(401),
-                ctx.json({
-                  error: "[mocked] Unauthorized",
-                  message: "[mocked] The provided token is invalid.",
-                })
-              );
-            }
+            mockSingleFailure
           )
         );
 

--- a/frontend/src/features/auth/authSlice.test.ts
+++ b/frontend/src/features/auth/authSlice.test.ts
@@ -760,6 +760,82 @@ describe(
     );
 
     test(
+      "confirmEmailAddress(tokenForConfirmingEmailAddress)" +
+        " + the HTTP request issued by that thunk-action is mocked to succeed",
+      async () => {
+        /* Arrange. */
+        requestInterceptionLayer.use(
+          rest.post(
+            "/api/confirm-email-address/:token_for_confirming_email_address",
+            requestHandlers.mockConfirmEmailAddress
+          )
+        );
+
+        /* Act. */
+        const confirmEmailAddressPromise = storeMock.dispatch(
+          confirmEmailAddress("mocked-token-for-confirming-email-address")
+        );
+
+        /* Assert. */
+        await expect(confirmEmailAddressPromise).resolves.toEqual(undefined);
+        expect(storeMock.getActions()).toEqual([
+          {
+            type: "auth/confirmEmailAddress/pending",
+          },
+          {
+            type: "auth/confirmEmailAddress/fulfilled",
+            payload: {
+              message:
+                "[mocked] You have confirmed your email address successfully." +
+                " You may now log in.",
+            },
+          },
+        ]);
+      }
+    );
+
+    test(
+      "confirmEmailAddress(tokenForConfirmingEmailAddress)" +
+        " + the HTTP request issued by that thunk-action is mocked to fail",
+      async () => {
+        /* Arrange. */
+        requestInterceptionLayer.use(
+          rest.post(
+            "/api/confirm-email-address/:token_for_confirming_email_address",
+            (req, res, ctx) => {
+              return res(
+                ctx.status(401),
+                ctx.json({
+                  error: "[mocked] Unauthorized",
+                  message: "[mocked] The provided token is invalid.",
+                })
+              );
+            }
+          )
+        );
+
+        /* Act. */
+        const confirmEmailAddressPromise = storeMock.dispatch(
+          confirmEmailAddress("mocked-token-for-confirming-email-address")
+        );
+
+        /* Assert. */
+        await expect(confirmEmailAddressPromise).rejects.toEqual(
+          "[mocked] The provided token is invalid."
+        );
+        expect(storeMock.getActions()).toEqual([
+          {
+            type: "auth/confirmEmailAddress/pending",
+          },
+          {
+            type: "auth/confirmEmailAddress/rejected",
+            error: "[mocked] The provided token is invalid.",
+          },
+        ]);
+      }
+    );
+
+    test(
       "issueJWSToken(email, password)" +
         " + the HTTP request issued by that thunk-action is mocked to succeed",
       async () => {

--- a/frontend/src/features/auth/authSlice.test.ts
+++ b/frontend/src/features/auth/authSlice.test.ts
@@ -19,6 +19,14 @@ import {
   createUserRejected,
   createUserFulfilled,
   createUser,
+  ActionTypesConfirmEmailAddress,
+  IActionConfirmEmailAddressPending,
+  IActionConfirmEmailAddressRejected,
+  IActionConfirmEmailAddressFulfilled,
+  confirmEmailAddressPending,
+  confirmEmailAddressRejected,
+  confirmEmailAddressFulfilled,
+  confirmEmailAddress,
   ActionTypesIssueJWSToken,
   IActionIssueJWSTokenPending,
   IActionIssueJWSTokenRejected,
@@ -72,6 +80,38 @@ describe("action creators", () => {
 
     expect(action).toEqual({
       type: "auth/createUser/fulfilled",
+    });
+  });
+
+  test("confirmEmailAddressPending", () => {
+    const action = confirmEmailAddressPending();
+
+    expect(action).toEqual({
+      type: "auth/confirmEmailAddress/pending",
+    });
+  });
+
+  test("confirmEmailAddressRejected", () => {
+    const action = confirmEmailAddressRejected(
+      "auth-confirmEmailAddress-rejected"
+    );
+
+    expect(action).toEqual({
+      type: "auth/confirmEmailAddress/rejected",
+      error: "auth-confirmEmailAddress-rejected",
+    });
+  });
+
+  test("confirmEmailAddressFulfilled", () => {
+    const action = confirmEmailAddressFulfilled(
+      "EMAIL-ADDRESS CONFIRMATION SUCCESSFUL - YOU MAY NOW LOG IN."
+    );
+
+    expect(action).toEqual({
+      type: "auth/confirmEmailAddress/fulfilled",
+      payload: {
+        message: "EMAIL-ADDRESS CONFIRMATION SUCCESSFUL - YOU MAY NOW LOG IN.",
+      },
     });
   });
 
@@ -243,6 +283,84 @@ describe("reducer", () => {
     };
     const action: IActionCreateUserFulfilled = {
       type: ActionTypesCreateUser.FULFILLED,
+    };
+
+    /* Act. */
+    const newState: IStateAuth = authReducer(initStAuth, action);
+
+    /* Assert. */
+    expect(newState).toEqual({
+      requestStatus: RequestStatus.SUCCEEDED,
+      requestError: null,
+      token: null,
+      hasValidToken: null,
+      loggedInUserProfile: null,
+    });
+  });
+
+  test("auth/confirmEmailAddress/pending", () => {
+    /* Arrange. */
+    initStAuth = {
+      ...INITIAL_STATE_AUTH,
+      requestStatus: RequestStatus.FAILED,
+      requestError: "auth-confirmEmailAddress-rejected",
+    };
+    const action: IActionConfirmEmailAddressPending = {
+      type: ActionTypesConfirmEmailAddress.PENDING,
+    };
+
+    /* Act. */
+    const newState: IStateAuth = authReducer(initStAuth, action);
+
+    /* Assert. */
+    expect(newState).toEqual({
+      requestStatus: RequestStatus.LOADING,
+      requestError: null,
+      token: null,
+      hasValidToken: null,
+      loggedInUserProfile: null,
+    });
+  });
+
+  test("auth/confirmEmailAddress/rejected", () => {
+    /* Arrange. */
+    initStAuth = {
+      ...INITIAL_STATE_AUTH,
+      requestStatus: RequestStatus.LOADING,
+      requestError: null,
+    };
+    const action: IActionConfirmEmailAddressRejected = {
+      type: ActionTypesConfirmEmailAddress.REJECTED,
+      error: "auth-confirmEmailAddress-rejected",
+    };
+
+    /* Act. */
+    const newState: IStateAuth = authReducer(initStAuth, action);
+
+    /* Assert. */
+    expect(newState).toEqual({
+      requestStatus: RequestStatus.FAILED,
+      requestError: "auth-confirmEmailAddress-rejected",
+      token: null,
+      hasValidToken: null,
+      loggedInUserProfile: null,
+    });
+  });
+
+  test("auth/confirmEmailAddress/fulfilled", () => {
+    /* Arrange. */
+    initStAuth = {
+      ...INITIAL_STATE_AUTH,
+      requestStatus: RequestStatus.LOADING,
+      requestError: null,
+    };
+    const action: IActionConfirmEmailAddressFulfilled = {
+      type: ActionTypesConfirmEmailAddress.FULFILLED,
+      payload: {
+        message:
+          "You have confirmed your email address successfully." +
+          " You may now log in.",
+      },
     };
 
     /* Act. */

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -160,7 +160,7 @@ export const confirmEmailAddress = (tokenForConfirmingEmailAddress: string) => {
         err.response.data.message ||
         "ERROR NOT FROM BACKEND BUT FROM FRONTEND THUNK-ACTION";
       dispatch(confirmEmailAddressRejected(responseBodyMessage));
-      return Promise.reject(err);
+      return Promise.reject(responseBodyMessage);
     }
   };
 };

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -85,6 +85,86 @@ export const createUser = (
   };
 };
 
+/* "auth/confirmEmailAddress" action creators. */
+export enum ActionTypesConfirmEmailAddress {
+  PENDING = "auth/confirmEmailAddress/pending",
+  REJECTED = "auth/confirmEmailAddress/rejected",
+  FULFILLED = "auth/confirmEmailAddress/fulfilled",
+}
+
+export interface IActionConfirmEmailAddressPending {
+  type: typeof ActionTypesConfirmEmailAddress.PENDING;
+}
+
+export interface IActionConfirmEmailAddressRejected {
+  type: typeof ActionTypesConfirmEmailAddress.REJECTED;
+  error: string;
+}
+
+export interface IActionConfirmEmailAddressFulfilled {
+  type: typeof ActionTypesConfirmEmailAddress.FULFILLED;
+  payload: {
+    message: string;
+  };
+}
+
+export const confirmEmailAddressPending =
+  (): IActionConfirmEmailAddressPending => ({
+    type: ActionTypesConfirmEmailAddress.PENDING,
+  });
+
+export const confirmEmailAddressRejected = (
+  error: string
+): IActionConfirmEmailAddressRejected => ({
+  type: ActionTypesConfirmEmailAddress.REJECTED,
+  error,
+});
+
+export const confirmEmailAddressFulfilled = (
+  message: string
+): IActionConfirmEmailAddressFulfilled => ({
+  type: ActionTypesConfirmEmailAddress.FULFILLED,
+  payload: {
+    message,
+  },
+});
+
+export type ActionConfirmEmailAddress =
+  | IActionConfirmEmailAddressPending
+  | IActionConfirmEmailAddressRejected
+  | IActionConfirmEmailAddressFulfilled;
+
+/* "auth/confirmEmailAddress" thunk-action creator */
+export const confirmEmailAddress = (tokenForConfirmingEmailAddress: string) => {
+  /*
+  TODO: (2024/03/13, 08:25)
+        fix the indentation in the following comment,
+        as well as in all other comments that contain the string "Create a thunk-action."
+  */
+  /*
+    Create a thunk-action.
+    When dispatched, it issues an HTTP request
+    to the backend's endpoint for confirming a (newly-created) User's email address.
+    */
+
+  return async (dispatch: Dispatch<ActionConfirmEmailAddress>) => {
+    dispatch(confirmEmailAddressPending());
+    try {
+      const response = await axios.post(
+        `/api/confirm-email-address/${tokenForConfirmingEmailAddress}`
+      );
+      dispatch(confirmEmailAddressFulfilled(response.data.message));
+      return Promise.resolve();
+    } catch (err) {
+      const responseBodyMessage =
+        err.response.data.message ||
+        "ERROR NOT FROM BACKEND BUT FROM FRONTEND THUNK-ACTION";
+      dispatch(confirmEmailAddressRejected(responseBodyMessage));
+      return Promise.reject(err);
+    }
+  };
+};
+
 /* "auth/issueJWSToken/" action creators */
 export enum ActionTypesIssueJWSToken {
   PENDING = "auth/issueJWSToken/pending",

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -428,6 +428,7 @@ export const authReducer = (
   state: IStateAuth = INITIAL_STATE_AUTH,
   action:
     | ActionCreateUser
+    | ActionConfirmEmailAddress
     | ActionIssueJWSToken
     | ActionFetchProfile
     | ActionRequestPasswordReset
@@ -449,6 +450,27 @@ export const authReducer = (
       };
 
     case ActionTypesCreateUser.FULFILLED:
+      return {
+        ...state,
+        requestStatus: RequestStatus.SUCCEEDED,
+        requestError: null,
+      };
+
+    case ActionTypesConfirmEmailAddress.PENDING:
+      return {
+        ...state,
+        requestStatus: RequestStatus.LOADING,
+        requestError: null,
+      };
+
+    case ActionTypesConfirmEmailAddress.REJECTED:
+      return {
+        ...state,
+        requestStatus: RequestStatus.FAILED,
+        requestError: action.error,
+      };
+
+    case ActionTypesConfirmEmailAddress.FULFILLED:
       return {
         ...state,
         requestStatus: RequestStatus.SUCCEEDED,

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -51,10 +51,10 @@ export const createUser = (
   password: string
 ) => {
   /*
-    Create a thunk-action.
-    When dispatched, it issues an HTTP request
-    to the backend's endpoint for creating a new User resource.
-    */
+  Create a thunk-action.
+  When dispatched, it issues an HTTP request
+  to the backend's endpoint for creating a new User resource.
+  */
 
   return async (dispatch: Dispatch<ActionCreateUser>) => {
     const config = {
@@ -137,15 +137,10 @@ export type ActionConfirmEmailAddress =
 /* "auth/confirmEmailAddress" thunk-action creator */
 export const confirmEmailAddress = (tokenForConfirmingEmailAddress: string) => {
   /*
-  TODO: (2024/03/13, 08:25)
-        fix the indentation in the following comment,
-        as well as in all other comments that contain the string "Create a thunk-action."
+  Create a thunk-action.
+  When dispatched, it issues an HTTP request
+  to the backend's endpoint for confirming a (newly-created) User's email address.
   */
-  /*
-    Create a thunk-action.
-    When dispatched, it issues an HTTP request
-    to the backend's endpoint for confirming a (newly-created) User's email address.
-    */
 
   return async (dispatch: Dispatch<ActionConfirmEmailAddress>) => {
     dispatch(confirmEmailAddressPending());
@@ -216,10 +211,10 @@ export type ActionIssueJWSToken =
 /* "auth/issueJWSToken" thunk-action creator */
 export const issueJWSToken = (email: string, password: string) => {
   /*
-    Create a thunk-action.
-    When dispatched, it issues an HTTP request
-    to the backend's endpoint for issuing a JSON Web Signature token.
-    */
+  Create a thunk-action.
+  When dispatched, it issues an HTTP request
+  to the backend's endpoint for issuing a JSON Web Signature token.
+  */
 
   return async (dispatch: Dispatch<ActionIssueJWSToken>) => {
     const config = {
@@ -302,10 +297,10 @@ export type ActionFetchProfile =
 /* "auth/fetchProfile" thunk-action creator */
 export const fetchProfile = () => {
   /*
-    Create a thunk-action.
-    When dispatched, it issues an HTTP request
-    to the backend's endpoint for fetching the Profile of a specific User.
-    */
+  Create a thunk-action.
+  When dispatched, it issues an HTTP request
+  to the backend's endpoint for fetching the Profile of a specific User.
+  */
 
   return async (dispatch: Dispatch<ActionFetchProfile>) => {
     const config = {
@@ -376,10 +371,10 @@ export type ActionRequestPasswordReset =
 /* "auth/requestPasswordReset" thunk-action creator */
 export const requestPasswordReset = (email: string) => {
   /*
-    Create a thunk-action.
-    When dispatched, it issues an HTTP request
-    to the backend's endpoint for requesting a password reset.
-    */
+  Create a thunk-action.
+  When dispatched, it issues an HTTP request
+  to the backend's endpoint for requesting a password reset.
+  */
 
   return async (dispatch: Dispatch<ActionRequestPasswordReset>) => {
     const config = {

--- a/frontend/src/features/examples/EditExample.tsx
+++ b/frontend/src/features/examples/EditExample.tsx
@@ -94,12 +94,12 @@ export const EditExample = () => {
           await dispatch(fetchExamples(examplesLinks.self));
         } else {
           /*
-            It _should_ be impossible for this block of code to ever be executed.
-  
-            Why?
-  
-            For the same reason as in the analogous block within <SingleExample>.
-            */
+          It _should_ be impossible for this block of code to ever be executed.
+
+          Why?
+
+          For the same reason as in the analogous block within <SingleExample>.
+          */
           await dispatch(fetchExamples(URL_FOR_FIRST_PAGE_OF_EXAMPLES));
         }
 

--- a/frontend/src/features/examples/OwnVocabTreasury.test.tsx
+++ b/frontend/src/features/examples/OwnVocabTreasury.test.tsx
@@ -23,12 +23,12 @@ const requestHandlersToMock: RestHandler<MockedRequest<DefaultRequestBody>>[] =
   [
     rest.get(
       "/api/examples",
-      createMockOneOrManyFailures(
-        "multiple failures",
-        401,
-        "[mocked] Unauthorized",
-        "[mocked] Authentication in the Basic Auth format is required."
-      )
+      createMockOneOrManyFailures("multiple failures", {
+        statusCode: 401,
+        error: "[mocked] Unauthorized",
+        message:
+          "[mocked] Authentication in the Basic Auth format is required.",
+      })
     ),
   ];
 

--- a/frontend/src/features/examples/OwnVocabTreasury.test.tsx
+++ b/frontend/src/features/examples/OwnVocabTreasury.test.tsx
@@ -19,18 +19,13 @@ import { Alerts } from "../alerts/Alerts";
 import { OwnVocabTreasury } from "./OwnVocabTreasury";
 
 /* Create an MSW "request-interception layer". */
+const mockMultipleFailures = createMockOneOrManyFailures("multiple failures", {
+  statusCode: 401,
+  error: "[mocked] Unauthorized",
+  message: "[mocked] Authentication in the Basic Auth format is required.",
+});
 const requestHandlersToMock: RestHandler<MockedRequest<DefaultRequestBody>>[] =
-  [
-    rest.get(
-      "/api/examples",
-      createMockOneOrManyFailures("multiple failures", {
-        statusCode: 401,
-        error: "[mocked] Unauthorized",
-        message:
-          "[mocked] Authentication in the Basic Auth format is required.",
-      })
-    ),
-  ];
+  [rest.get("/api/examples", mockMultipleFailures)];
 
 const requestInterceptionLayer: SetupServerApi = setupServer(
   ...requestHandlersToMock

--- a/frontend/src/features/examples/OwnVocabTreasury.test.tsx
+++ b/frontend/src/features/examples/OwnVocabTreasury.test.tsx
@@ -20,7 +20,17 @@ import { OwnVocabTreasury } from "./OwnVocabTreasury";
 
 /* Create an MSW "request-interception layer". */
 const requestHandlersToMock: RestHandler<MockedRequest<DefaultRequestBody>>[] =
-  [rest.get("/api/examples", createMockOneOrManyFailures("multiple failures"))];
+  [
+    rest.get(
+      "/api/examples",
+      createMockOneOrManyFailures(
+        "multiple failures",
+        401,
+        "[mocked] Unauthorized",
+        "[mocked] Authentication in the Basic Auth format is required."
+      )
+    ),
+  ];
 
 const requestInterceptionLayer: SetupServerApi = setupServer(
   ...requestHandlersToMock

--- a/frontend/src/features/examples/OwnVocabTreasury.tsx
+++ b/frontend/src/features/examples/OwnVocabTreasury.tsx
@@ -66,10 +66,10 @@ export const OwnVocabTreasury = () => {
     examplesLinks.self !== null
   ) {
     /*
-      Arrange for the user to be shown
-      either the most-recently visited page of her Own VocabTreasury
-      or the last page thereof.
-      */
+    Arrange for the user to be shown
+    either the most-recently visited page of her Own VocabTreasury
+    or the last page thereof.
+    */
     console.log("    from /examples/:id (i.e. <SingleExample>)");
 
     if (
@@ -79,12 +79,12 @@ export const OwnVocabTreasury = () => {
       examplesLinks.last !== null
     ) {
       /*
-        Handle the case, where
-        (a) the most-recently visited page of the user's Own VocabTreasury used to
-            the last page thereof;
-        (b) that page used to contain a single example;
-        and (c) the user used the frontend UI to delete that example.
-        */
+      Handle the case, where
+      (a) the most-recently visited page of the user's Own VocabTreasury used to
+          the last page thereof;
+      (b) that page used to contain a single example;
+      and (c) the user used the frontend UI to delete that example.
+      */
       initialExamplesUrl = examplesLinks.last;
     } else {
       initialExamplesUrl = examplesLinks.self;
@@ -169,13 +169,15 @@ export const OwnVocabTreasury = () => {
     console.log("    examplesMeta.page !== null");
 
     /*
-      TODO: find out why
-            this block requires the Non-null Assertion Operator (Postfix !) to be used twice,
-            despite the fact this block appears to be in line with the recommendation on
-            https://stackoverflow.com/a/46915314
-  
-            the "Non-null Assertion Operator (Postfix !)" is described on
-            https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#strictnullchecks-on
+    TODO: (2023/10/29, 15:06)
+    
+          find out why
+          this block requires the Non-null Assertion Operator (Postfix !) to be used twice,
+          despite the fact this block appears to be in line with the recommendation on
+          https://stackoverflow.com/a/46915314
+
+          the "Non-null Assertion Operator (Postfix !)" is described on
+          https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#strictnullchecks-on
       */
     const paginationCtrlBtnPrev: JSX.Element =
       examplesLinks.prev !== null ? (

--- a/frontend/src/features/examples/RecordNewExample.tsx
+++ b/frontend/src/features/examples/RecordNewExample.tsx
@@ -73,11 +73,11 @@ export const RecordNewExample = () => {
         dispatch(alertsCreate(id, "EXAMPLE CREATION SUCCESSFUL"));
 
         /*
-          Force
-          the contents within the "meta" and "links" sub-slices
-          of the app-level state's "examples" slice
-          to be updated.
-          */
+        Force
+        the contents within the "meta" and "links" sub-slices
+        of the app-level state's "examples" slice
+        to be updated.
+        */
         await dispatch(fetchExamples(URL_FOR_FIRST_PAGE_OF_EXAMPLES));
 
         const locationDescriptor = {

--- a/frontend/src/features/examples/SingleExample.tsx
+++ b/frontend/src/features/examples/SingleExample.tsx
@@ -91,7 +91,7 @@ export const SingleExample = () => {
   const handleClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
 
-    console.log("    submitting <SingleExample>'s form");
+    console.log("    clicking <SingleExample>'s button");
 
     const id: string = uuidv4();
     try {
@@ -103,16 +103,16 @@ export const SingleExample = () => {
         await dispatch(fetchExamples(examplesLinks.self));
       } else {
         /*
-          It _should_ be impossible for this block of code to ever be executed.
-  
-          Why?
-  
-          Because this component may only be rendered
-          after the user's browser has loaded the /own-vocabtreasury URL,
-          which causes React
-          to first render <OwnVocabTreasury>
-          and to then run its effect function.
-          */
+        It _should_ be impossible for this block of code to ever be executed.
+
+        Why?
+
+        Because this component may only be rendered
+        after the user's browser has loaded the /own-vocabtreasury URL,
+        which causes React
+        to first render <OwnVocabTreasury>
+        and to then run its effect function.
+        */
         await dispatch(fetchExamples(URL_FOR_FIRST_PAGE_OF_EXAMPLES));
       }
 

--- a/frontend/src/features/examples/examplesSlice.test.ts
+++ b/frontend/src/features/examples/examplesSlice.test.ts
@@ -1117,7 +1117,12 @@ describe(
         requestInterceptionLayer.use(
           rest.get(
             "/api/examples",
-            createMockOneOrManyFailures("single failure")
+            createMockOneOrManyFailures(
+              "single failure",
+              401,
+              "[mocked] Unauthorized",
+              "[mocked] Authentication in the Basic Auth format is required."
+            )
           )
         );
 
@@ -1195,7 +1200,12 @@ describe(
         requestInterceptionLayer.use(
           rest.post(
             "/api/examples",
-            createMockOneOrManyFailures("single failure")
+            createMockOneOrManyFailures(
+              "single failure",
+              401,
+              "[mocked] Unauthorized",
+              "[mocked] Authentication in the Basic Auth format is required."
+            )
           )
         );
 
@@ -1267,7 +1277,12 @@ describe(
         requestInterceptionLayer.use(
           rest.delete(
             "/api/examples/:id",
-            createMockOneOrManyFailures("single failure")
+            createMockOneOrManyFailures(
+              "single failure",
+              401,
+              "[mocked] Unauthorized",
+              "[mocked] Authentication in the Basic Auth format is required."
+            )
           )
         );
 
@@ -1344,7 +1359,12 @@ describe(
         requestInterceptionLayer.use(
           rest.put(
             "/api/examples/:id",
-            createMockOneOrManyFailures("single failure")
+            createMockOneOrManyFailures(
+              "single failure",
+              401,
+              "[mocked] Unauthorized",
+              "[mocked] Authentication in the Basic Auth format is required."
+            )
           )
         );
 

--- a/frontend/src/features/examples/examplesSlice.test.ts
+++ b/frontend/src/features/examples/examplesSlice.test.ts
@@ -1111,12 +1111,12 @@ describe(
         requestInterceptionLayer.use(
           rest.get(
             "/api/examples",
-            createMockOneOrManyFailures(
-              "single failure",
-              401,
-              "[mocked] Unauthorized",
-              "[mocked] Authentication in the Basic Auth format is required."
-            )
+            createMockOneOrManyFailures("single failure", {
+              statusCode: 401,
+              error: "[mocked] Unauthorized",
+              message:
+                "[mocked] Authentication in the Basic Auth format is required.",
+            })
           )
         );
 
@@ -1194,12 +1194,12 @@ describe(
         requestInterceptionLayer.use(
           rest.post(
             "/api/examples",
-            createMockOneOrManyFailures(
-              "single failure",
-              401,
-              "[mocked] Unauthorized",
-              "[mocked] Authentication in the Basic Auth format is required."
-            )
+            createMockOneOrManyFailures("single failure", {
+              statusCode: 401,
+              error: "[mocked] Unauthorized",
+              message:
+                "[mocked] Authentication in the Basic Auth format is required.",
+            })
           )
         );
 
@@ -1271,12 +1271,12 @@ describe(
         requestInterceptionLayer.use(
           rest.delete(
             "/api/examples/:id",
-            createMockOneOrManyFailures(
-              "single failure",
-              401,
-              "[mocked] Unauthorized",
-              "[mocked] Authentication in the Basic Auth format is required."
-            )
+            createMockOneOrManyFailures("single failure", {
+              statusCode: 401,
+              error: "[mocked] Unauthorized",
+              message:
+                "[mocked] Authentication in the Basic Auth format is required.",
+            })
           )
         );
 
@@ -1353,12 +1353,12 @@ describe(
         requestInterceptionLayer.use(
           rest.put(
             "/api/examples/:id",
-            createMockOneOrManyFailures(
-              "single failure",
-              401,
-              "[mocked] Unauthorized",
-              "[mocked] Authentication in the Basic Auth format is required."
-            )
+            createMockOneOrManyFailures("single failure", {
+              statusCode: 401,
+              error: "[mocked] Unauthorized",
+              message:
+                "[mocked] Authentication in the Basic Auth format is required.",
+            })
           )
         );
 

--- a/frontend/src/features/examples/examplesSlice.test.ts
+++ b/frontend/src/features/examples/examplesSlice.test.ts
@@ -1108,16 +1108,17 @@ describe(
         " + the HTTP request issued by that thunk-action is mocked to fail",
       async () => {
         /* Arrange. */
+        const mockSingleFailure = createMockOneOrManyFailures(
+          "single failure",
+          {
+            statusCode: 401,
+            error: "[mocked] Unauthorized",
+            message:
+              "[mocked] Authentication in the Basic Auth format is required.",
+          }
+        );
         requestInterceptionLayer.use(
-          rest.get(
-            "/api/examples",
-            createMockOneOrManyFailures("single failure", {
-              statusCode: 401,
-              error: "[mocked] Unauthorized",
-              message:
-                "[mocked] Authentication in the Basic Auth format is required.",
-            })
-          )
+          rest.get("/api/examples", mockSingleFailure)
         );
 
         /* Act. */
@@ -1191,16 +1192,17 @@ describe(
         "+ the HTTP request issued by that thunk-action is mocked to fail",
       async () => {
         /* Arrange. */
+        const mockSingleFailure = createMockOneOrManyFailures(
+          "single failure",
+          {
+            statusCode: 401,
+            error: "[mocked] Unauthorized",
+            message:
+              "[mocked] Authentication in the Basic Auth format is required.",
+          }
+        );
         requestInterceptionLayer.use(
-          rest.post(
-            "/api/examples",
-            createMockOneOrManyFailures("single failure", {
-              statusCode: 401,
-              error: "[mocked] Unauthorized",
-              message:
-                "[mocked] Authentication in the Basic Auth format is required.",
-            })
-          )
+          rest.post("/api/examples", mockSingleFailure)
         );
 
         /* Act. */
@@ -1268,16 +1270,17 @@ describe(
         " + the HTTP request issued by that thunk-action is mocked to fail",
       async () => {
         /* Arrange. */
+        const mockSingleFailure = createMockOneOrManyFailures(
+          "single failure",
+          {
+            statusCode: 401,
+            error: "[mocked] Unauthorized",
+            message:
+              "[mocked] Authentication in the Basic Auth format is required.",
+          }
+        );
         requestInterceptionLayer.use(
-          rest.delete(
-            "/api/examples/:id",
-            createMockOneOrManyFailures("single failure", {
-              statusCode: 401,
-              error: "[mocked] Unauthorized",
-              message:
-                "[mocked] Authentication in the Basic Auth format is required.",
-            })
-          )
+          rest.delete("/api/examples/:id", mockSingleFailure)
         );
 
         /* Act. */
@@ -1350,16 +1353,17 @@ describe(
         " + the HTTP request issued by that thunk-action is mocked to fail",
       async () => {
         /* Arrange. */
+        const mockSingleFailure = createMockOneOrManyFailures(
+          "single failure",
+          {
+            statusCode: 401,
+            error: "[mocked] Unauthorized",
+            message:
+              "[mocked] Authentication in the Basic Auth format is required.",
+          }
+        );
         requestInterceptionLayer.use(
-          rest.put(
-            "/api/examples/:id",
-            createMockOneOrManyFailures("single failure", {
-              statusCode: 401,
-              error: "[mocked] Unauthorized",
-              message:
-                "[mocked] Authentication in the Basic Auth format is required.",
-            })
-          )
+          rest.put("/api/examples/:id", mockSingleFailure)
         );
 
         /* Act. */

--- a/frontend/src/features/examples/examplesSlice.test.ts
+++ b/frontend/src/features/examples/examplesSlice.test.ts
@@ -997,12 +997,6 @@ const createStoreMock = configureMockStore<
   IState,
   ThunkDispatch<IState, any, AnyAction>
 >([thunkMiddleware]);
-/*
-MockStoreEnhanced<
-    IState,
-    ThunkDispatch<IState, any, AnyAction>
->
-*/
 
 describe(
   "dispatching of async thunk-actions," +

--- a/frontend/src/features/examples/examplesSlice.ts
+++ b/frontend/src/features/examples/examplesSlice.ts
@@ -91,11 +91,11 @@ export type ActionFetchExamples =
 /* "examples/fetchExamples" thunk-action creator */
 export const fetchExamples = (urlForOnePageOfExamples: string) => {
   /*
-    Create a thunk-action.
-    When dispatched, it issues an HTTP request
-    to the backend's endpoint for fetching Example resources,
-    which are associated with a specific User.
-    */
+  Create a thunk-action.
+  When dispatched, it issues an HTTP request
+  to the backend's endpoint for fetching Example resources,
+  which are associated with a specific User.
+  */
 
   return async (dispatch: Dispatch<ActionFetchExamples>) => {
     const config = {
@@ -188,11 +188,11 @@ export const createExample = (
   contentTranslation: string | null
 ) => {
   /*
-    Create a thunk-action.
-    When dispatched, it issues an HTTP request
-    to the backend's endpoint for creating a new Example resource,
-    which will be associated with a specific User.
-    */
+  Create a thunk-action.
+  When dispatched, it issues an HTTP request
+  to the backend's endpoint for creating a new Example resource,
+  which will be associated with a specific User.
+  */
   return async (dispatch: Dispatch<ActionCreateExample>) => {
     const config = {
       headers: {
@@ -283,11 +283,11 @@ export type ActionDeleteExample =
 /* "examples/deleteExample" thunk-action creator */
 export const deleteExample = (exampleId: number) => {
   /*
-    Create a thunk-action.
-    When dispatched, it issues an HTTP request
-    to the backend's endpoint for deleting an existing Example resource,
-    which must be associated with a specific User.
-    */
+  Create a thunk-action.
+  When dispatched, it issues an HTTP request
+  to the backend's endpoint for deleting an existing Example resource,
+  which must be associated with a specific User.
+  */
   return async (dispatch: Dispatch<ActionDeleteExample>) => {
     const config = {
       headers: {
@@ -376,11 +376,11 @@ export const editExample = (
   }
 ) => {
   /*
-    Create a thunk-action.
-    When dispatched, it issues an HTTP request
-    to the backend's endpoint for editing an existing Example resource,
-    which must be associated with a specific User.
-    */
+  Create a thunk-action.
+  When dispatched, it issues an HTTP request
+  to the backend's endpoint for editing an existing Example resource,
+  which must be associated with a specific User.
+  */
   return async (dispatch: Dispatch<ActionEditExample>) => {
     const config = {
       headers: {

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -80,6 +80,21 @@ const mockCreateUser = (
   );
 };
 
+const mockConfirmEmailAddress = (
+  req: RestRequest<DefaultRequestBody, RequestParams>,
+  res: ResponseComposition<any>,
+  ctx: RestContext
+) => {
+  return res.once(
+    ctx.status(200),
+    ctx.json({
+      message:
+        "[mocked] You have confirmed your email address successfully." +
+        " You may now log in.",
+    })
+  );
+};
+
 const mockIssueJWSToken = (
   req: RestRequest<DefaultRequestBody, RequestParams>,
   res: ResponseComposition<any>,
@@ -346,6 +361,7 @@ export class RequestHandlingFacilitator {
 
 export const requestHandlers = {
   mockCreateUser,
+  mockConfirmEmailAddress,
   mockIssueJWSToken,
   mockFetchUserProfile,
   mockRequestPasswordReset,

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -6,7 +6,7 @@ import {
   RestRequest,
 } from "msw";
 
-import { IExampleFromBackend } from "./types";
+import { IExampleFromBackend, IOptionsForCreatingMockHandler } from "./types";
 import {
   MOCK_PROFILE,
   MOCK_EXAMPLES,
@@ -20,15 +20,8 @@ i.e. independent of the other ones.
 */
 export const createMockOneOrManyFailures = (
   description: string,
-  statusCode: number,
-  error: string,
-  message: string
+  options: IOptionsForCreatingMockHandler
 ) => {
-  // const statusCode: number = 401;
-  // const error: string = "[mocked] Unauthorized";
-  // const message: string =
-  //   "[mocked] Authentication in the Basic Auth format is required.";
-
   switch (description) {
     case "single failure": {
       const mockSingleFailure = (
@@ -37,10 +30,10 @@ export const createMockOneOrManyFailures = (
         ctx: RestContext
       ) => {
         return res.once(
-          ctx.status(statusCode),
+          ctx.status(options.statusCode),
           ctx.json({
-            error,
-            message,
+            error: options.error,
+            message: options.message,
           })
         );
       };
@@ -55,10 +48,10 @@ export const createMockOneOrManyFailures = (
         ctx: RestContext
       ) => {
         return res(
-          ctx.status(statusCode),
+          ctx.status(options.statusCode),
           ctx.json({
-            error,
-            message,
+            error: options.error,
+            message: options.message,
           })
         );
       };

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -268,52 +268,6 @@ export class RequestHandlingFacilitator {
       res: ResponseComposition<PutResponseBody>,
       ctx: RestContext
     ) => {
-      /*
-      const { id: exampleIdStr } = req.params;
-      const exampleId: number = parseInt(exampleIdStr);
-
-      const edited_source_language = (req!.body as Record<string, any>)
-        .source_language;
-      const edited_new_word = (req!.body as Record<string, any>).new_word;
-      const edited_content = (req!.body as Record<string, any>).content;
-      const edited_content_translation = (req!.body as Record<string, any>)
-        .content_translation;
-
-      this.mockExamples = this.mockExamples.map(
-        (example: IExampleFromBackend) => {
-          if (example.id !== exampleId) {
-            return example;
-          }
-
-          // Emulate the backend's route-handling function for
-          // PUT requests to /api/examples/:id .
-          const editedExample: IExampleFromBackend = {
-            ...example,
-          };
-          if (edited_source_language !== undefined) {
-            editedExample.source_language = edited_source_language;
-          }
-          if (edited_new_word !== undefined) {
-            editedExample.new_word = edited_new_word;
-          }
-          if (edited_content !== undefined) {
-            editedExample.content = edited_content;
-          }
-          if (edited_content_translation !== undefined) {
-            editedExample.content_translation = edited_content_translation;
-          }
-
-          return editedExample;
-        }
-      );
-
-      const editedExample = this.mockExamples.filter(
-        (entry: IExampleFromBackend) => entry.id === exampleId
-      )[0];
-
-      return res.once(ctx.status(200), ctx.json(editedExample));
-      */
-
       const exampleId: number = parseInt(req.params.id);
       const exampleIndex: number = this.mockExamples.findIndex(
         (e: IExampleFromBackend) => e.id === exampleId

--- a/frontend/src/testHelpers.ts
+++ b/frontend/src/testHelpers.ts
@@ -18,11 +18,16 @@ Mock handlers for HTTP requests.
 Each of these mock handlers is "lone-standing",
 i.e. independent of the other ones.
 */
-export const createMockOneOrManyFailures = (description: string) => {
-  const statusCode: number = 401;
-  const error: string = "[mocked] Unauthorized";
-  const message: string =
-    "[mocked] Authentication in the Basic Auth format is required.";
+export const createMockOneOrManyFailures = (
+  description: string,
+  statusCode: number,
+  error: string,
+  message: string
+) => {
+  // const statusCode: number = 401;
+  // const error: string = "[mocked] Unauthorized";
+  // const message: string =
+  //   "[mocked] Authentication in the Basic Auth format is required.";
 
   switch (description) {
     case "single failure": {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -86,3 +86,9 @@ export interface IState {
   auth: IStateAuth;
   examples: IStateExamples;
 }
+
+export interface IOptionsForCreatingMockHandler {
+  statusCode: number;
+  error: string;
+  message: string;
+}


### PR DESCRIPTION
this pull request:

- edits the email-address-confirmation instructions
  that get sent
  (to a newly-created user's email address)
  by the request handler for `POST /api/users` requests

- creates `frontend/src/features/auth/ConfirmEmailAddress.tsx`

- makes the `createMockOneOrManyFailures` function,
  which is defined within `frontend/src/testHelpers.ts`,
  more general

- fixes the indentation within block comments in `src/frontend/`

- makes updates to `.vscode/launch.json` and `.vscode/settngs.json`,
  which weren't strictly necessary (at this very moment) but are a helpful investment in the future